### PR TITLE
Add frontend-mvn-plugin to do npm install & build on mvn install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 target
 .idea
 *.iml
+.settings
+.vscode
+.classpath
+.project
+node/
+ui/dist
+ui/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-target
+# IDE ignores
 .idea
 *.iml
 .settings
 .vscode
 .classpath
 .project
+
+# Java ignores
+target
+
+# UI ignores
 node/
 ui/dist
 ui/node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "prebuild": "cd ui && npm install && npm run build"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,32 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>1.9.1</version>
+        <executions>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>v12.17.0</nodeVersion>
+              <npmVersion>6.14.4</npmVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm run prebuild</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run prebuild</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "kafka-java-vertx-starter-ui",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "test",
-    "build": "webpack"
+    "build": "ls"
   },
   "author": "",
   "license": "Apache-2.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,8 @@
   "description": "UI for the Kafka Java Vertx starter application",
   "main": "src/index.js",
   "scripts": {
-    "test": "test"
+    "test": "test",
+    "build": "webpack"
   },
   "author": "",
   "license": "Apache-2.0"


### PR DESCRIPTION
This commit introduces the frontend-mvn-plugin which allows us to automatically run the npm install and build steps when we run `mvn install`.

Closes: #1 