### PR TITLE
feat: Add Consumer/ProducerMessage element components

### DIFF
--- a/ui/.storybook/webpack.config.js
+++ b/ui/.storybook/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
 const miniCssExtractPlugin = require('mini-css-extract-plugin');
+const { webpackAliases } = require('../moduleAliases');
+
 const cssPluginConfiguration = {
   filename: '[name].bundle.css',
 };
@@ -34,6 +36,11 @@ module.exports = async ({ config, mode }) => {
   config.plugins.push(new miniCssExtractPlugin(cssPluginConfiguration));
 
   config.entry.push(path.join(__dirname, '../src/Bootstrap/index.scss'));
+
+  config.resolve = {
+    alias: webpackAliases,
+    extensions: ['.js'],
+  };
 
   return config;
 };

--- a/ui/src/Bootstrap/index.scss
+++ b/ui/src/Bootstrap/index.scss
@@ -10,10 +10,12 @@ $font-prefix: '~@ibm/plex'; // path to where the font files are
 @import '@carbon/type/scss/styles';
 @import '@carbon/type/scss/font-family';
 @import '@carbon/type/scss/reset';
+@import 'carbon-components/scss/components/tile/_tile.scss';
 
 // include carbon global mixin/changes
 @include carbon--type-reset();
 
 // Import all other .scss files here
+@import '../Elements/Message/Message.scss';
 @import '../Elements/Text/Text.scss';
 @import '../Groups/Counter/Counter.scss';

--- a/ui/src/Bootstrap/index.scss
+++ b/ui/src/Bootstrap/index.scss
@@ -10,6 +10,7 @@ $font-prefix: '~@ibm/plex'; // path to where the font files are
 @import '@carbon/type/scss/styles';
 @import '@carbon/type/scss/font-family';
 @import '@carbon/type/scss/reset';
+@import 'carbon-components/scss/components/tag/_tag.scss';
 @import 'carbon-components/scss/components/tile/_tile.scss';
 
 // include carbon global mixin/changes

--- a/ui/src/Elements/Message/Message.assets.js
+++ b/ui/src/Elements/Message/Message.assets.js
@@ -1,12 +1,2 @@
 export const CONSUMER = 'consumer';
 export const PRODUCER = 'producer';
-
-export const translations = {
-  en: {
-    PARTITION: 'Partition',
-    OFFSET: 'Offset',
-    CONSUMED_AT: 'Consumed at ${timestamp}',
-    SIZE: 'Size: ${bytesCount} B',
-    PAYLOAD: 'Payload',
-  },
-};

--- a/ui/src/Elements/Message/Message.assets.js
+++ b/ui/src/Elements/Message/Message.assets.js
@@ -1,0 +1,12 @@
+export const CONSUMER = 'consumer';
+export const PRODUCER = 'producer';
+
+export const translations = {
+  en: {
+    PARTITION: 'Partition',
+    OFFSET: 'Offset',
+    CONSUMED_AT: 'Consumed at ${timestamp}',
+    SIZE: 'Size: ${bytesCount} B',
+    PAYLOAD: 'Payload',
+  },
+};

--- a/ui/src/Elements/Message/Message.i18n.json
+++ b/ui/src/Elements/Message/Message.i18n.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "NEWEST": "Newest",
+    "PARTITION": "Partition",
+    "OFFSET": "Offset",
+    "CONSUMED_AT": "Consumed at ${timestamp}",
+    "SIZE": "Size: ${bytesCount} B",
+    "PAYLOAD": "Payload"
+  }
+}

--- a/ui/src/Elements/Message/Message.scss
+++ b/ui/src/Elements/Message/Message.scss
@@ -1,0 +1,18 @@
+.Message {
+    &__consumer-details {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+
+    &__icon {
+
+      &--checkmark {
+        fill: $support-02;
+      }
+
+      &--error {
+        fill: $support-01;
+      }
+    }
+}

--- a/ui/src/Elements/Message/Message.scss
+++ b/ui/src/Elements/Message/Message.scss
@@ -8,11 +8,15 @@
     &__icon {
 
       &--checkmark {
-        fill: $support-02;
+        fill: $icon-02;
       }
 
       &--error {
         fill: $support-01;
       }
+    }
+
+    &--producer-first &__icon--checkmark {
+      fill: $support-02;
     }
 }

--- a/ui/src/Elements/Message/Message.spec.js
+++ b/ui/src/Elements/Message/Message.spec.js
@@ -86,6 +86,26 @@ describe('Message Element component', () => {
       ).toBeInTheDocument();
       expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
       expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+      expect(
+        getByText(confirmHasClassNames('Message__tag-consumer-first'))
+      ).toBeInTheDocument();
+    });
+
+    it('renders the expected component with the isSelected flag', () => {
+      const { getByText } = render(
+        <ConsumerMessage message={testMessage} isSelected />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--consumer',
+            'Message--consumer-selected'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
     });
 
     it('renders the expected component with an interaction handler function', () => {
@@ -186,6 +206,26 @@ describe('Message Element component', () => {
             'Message',
             'Message--producer',
             'Message--producer-first'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+      expect(
+        getByText(confirmHasClassNames('Message__tag-producer-first'))
+      ).toBeInTheDocument();
+    });
+
+    it('renders the expected component with the isSelected flag', () => {
+      const { getByText } = render(
+        <ProducerMessage message={testMessage} isSelected />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--producer',
+            'Message--producer-selected'
           )
         )
       ).toBeInTheDocument();

--- a/ui/src/Elements/Message/Message.spec.js
+++ b/ui/src/Elements/Message/Message.spec.js
@@ -1,0 +1,239 @@
+import React from 'react';
+import { ProducerMessage, ConsumerMessage } from './index.js';
+import { render, fireEvent } from 'TestUtils';
+
+describe('Message Element component', () => {
+  const testClassName = 'testCssClass';
+  const testTimestamp = new Date();
+  const testTimestampLocaleStringRegex = new RegExp(
+    `.*${testTimestamp.toLocaleString()}`
+  );
+  const testValue = 'Test value data';
+  const testValueSizeRegex = new RegExp(`.*\\s${testValue.length}\\s`);
+  const testMessage = {
+    topic: 'demo',
+    partition: 2,
+    offset: 1000,
+    timestamp: testTimestamp.getTime(),
+    value: testValue,
+  };
+  const testError = {
+    message: 'Test error',
+  };
+
+  const confirmHasClassNames = (...classNamesExpected) => (content, node) =>
+    classNamesExpected.every((className) => node.classList.contains(className)); // has all the expected classnames
+
+  describe('ConsumerMessage component', () => {
+    it('renders the expected component', () => {
+      const { getByText } = render(<ConsumerMessage message={testMessage} />);
+      expect(
+        getByText(confirmHasClassNames('Message', 'Message--consumer'))
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+      expect(getByText(testTimestampLocaleStringRegex)).toBeInTheDocument();
+      expect(getByText(testMessage.value)).toBeInTheDocument();
+      expect(getByText(testValueSizeRegex)).toBeInTheDocument();
+    });
+
+    it('renders the expected component with a custom class name', () => {
+      const { getByText } = render(
+        <ConsumerMessage message={testMessage} className={testClassName} />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames('Message', 'Message--consumer', testClassName)
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+      expect(getByText(testTimestampLocaleStringRegex)).toBeInTheDocument();
+      expect(getByText(testMessage.value)).toBeInTheDocument();
+      expect(getByText(testValueSizeRegex)).toBeInTheDocument();
+    });
+
+    it('renders the expected component with an empty message value', () => {
+      const { getByText } = render(
+        <ConsumerMessage
+          message={{ ...testMessage, value: '' }}
+          className={testClassName}
+        />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames('Message', 'Message--consumer', testClassName)
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+      expect(getByText(testTimestampLocaleStringRegex)).toBeInTheDocument();
+      expect(getByText(/.*\s0\s/)).toBeInTheDocument(); // Payload size is 0
+    });
+
+    it('renders the expected component with the isFirst flag', () => {
+      const { getByText } = render(
+        <ConsumerMessage message={testMessage} isFirst />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--consumer',
+            'Message--consumer-first'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+    });
+
+    it('renders the expected component with an interaction handler function', () => {
+      const testOnInteraction = jest.fn();
+      const { getByText } = render(
+        <ConsumerMessage
+          message={testMessage}
+          onInteraction={testOnInteraction}
+        />
+      );
+
+      expect(testOnInteraction).toHaveBeenCalledTimes(0);
+      fireEvent.click(
+        getByText(confirmHasClassNames('Message__tile--consumer'))
+      );
+      expect(testOnInteraction).toHaveBeenCalledTimes(1);
+      expect(testOnInteraction).toHaveBeenCalledWith(
+        expect.anything(),
+        'consumer',
+        testMessage
+      );
+    });
+
+    it('renders the expected component with an error message', () => {
+      const { getByText, queryByText } = render(
+        <ConsumerMessage error={testError} />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--consumer',
+            'Message--consumer-error'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testError.message)).toBeInTheDocument();
+      expect(
+        queryByText(testTimestampLocaleStringRegex)
+      ).not.toBeInTheDocument();
+      expect(
+        queryByText(testMessage.offset.toString())
+      ).not.toBeInTheDocument();
+      expect(
+        queryByText(testTimestampLocaleStringRegex)
+      ).not.toBeInTheDocument();
+      expect(queryByText(testMessage.value)).not.toBeInTheDocument();
+      expect(queryByText(testValueSizeRegex)).not.toBeInTheDocument();
+    });
+
+    it('renders the expected component with a custom class name and an error message', () => {
+      const { getByText } = render(
+        <ConsumerMessage error={testError} className={testClassName} />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--consumer',
+            'Message--consumer-error',
+            testClassName
+          )
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('ProducerMessage component', () => {
+    it('renders the expected component', () => {
+      const { getByText } = render(<ProducerMessage message={testMessage} />);
+      expect(
+        getByText(confirmHasClassNames('Message', 'Message--producer'))
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+    });
+
+    it('renders the expected component with a custom class name', () => {
+      const { getByText } = render(
+        <ProducerMessage message={testMessage} className={testClassName} />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames('Message', 'Message--producer', testClassName)
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+    });
+
+    it('renders the expected component with the isFirst flag', () => {
+      const { getByText } = render(
+        <ProducerMessage message={testMessage} isFirst />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--producer',
+            'Message--producer-first'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testMessage.partition.toString())).toBeInTheDocument();
+      expect(getByText(testMessage.offset.toString())).toBeInTheDocument();
+    });
+
+    it('renders the expected component with an interaction handler function', () => {
+      const testOnInteraction = jest.fn();
+      const { getByText } = render(
+        <ProducerMessage
+          message={testMessage}
+          onInteraction={testOnInteraction}
+        />
+      );
+
+      expect(testOnInteraction).toHaveBeenCalledTimes(0);
+      fireEvent.click(
+        getByText(confirmHasClassNames('Message__tile--producer'))
+      );
+      expect(testOnInteraction).toHaveBeenCalledTimes(1);
+      expect(testOnInteraction).toHaveBeenCalledWith(
+        expect.anything(),
+        'producer',
+        testMessage
+      );
+    });
+
+    it('renders the expected component with an error message', () => {
+      const { getByText, queryByText } = render(
+        <ProducerMessage error={testError} />
+      );
+      expect(
+        getByText(
+          confirmHasClassNames(
+            'Message',
+            'Message--producer',
+            'Message--producer-error'
+          )
+        )
+      ).toBeInTheDocument();
+      expect(getByText(testError.message)).toBeInTheDocument();
+      expect(
+        queryByText(testMessage.offset.toString())
+      ).not.toBeInTheDocument();
+      expect(
+        queryByText(testMessage.partition.toString())
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/Elements/Message/Message.stories.js
+++ b/ui/src/Elements/Message/Message.stories.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
+import {
+  ConsumerMessage,
+  ProducerMessage,
+} from './index.js';
+import MessageReadme from './README.md';
+
+const renderHelper = (
+  Component,
+  defaultErrorMessage,
+  defaultMessagePartition = 0,
+  defaultMessageOffset = 100,
+  defaultMessageValue = 'Hello World!',
+  defaultMessageTimestamp = new Date().getTime(),
+) => () => {
+  const message = {
+    topic: 'demo'
+  };
+  message.partition = number('Message partition', defaultMessagePartition);
+  message.offset = number('Message offset', defaultMessageOffset);
+  message.value = text('Message value', defaultMessageValue);
+  message.timestamp = number('Message timestamp', defaultMessageTimestamp);
+
+  const className = text('Custom CSS classname', undefined);
+  const props = {
+    message,
+    className,
+    onInteraction: action('handleClick'),
+  };
+
+  const errorMessage = text('Error message', defaultErrorMessage);
+  if (errorMessage) {
+    props.error = {
+      message: errorMessage
+    };
+  }
+
+  return <Component {...props}/>;
+};
+
+storiesOf('Elements/Message', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withInfo)
+  .addParameters({
+    readme: {
+      sidebar: MessageReadme,
+    },
+  })
+  .add(
+    'ConsumerMessage component (default props)',
+    renderHelper(ConsumerMessage)
+  )
+  .add(
+    'ProducerMessage component (default props)',
+    renderHelper(ProducerMessage)
+  )
+  .add(
+    'ConsumerMessage component with error',
+    renderHelper(ConsumerMessage, 'An error occurred with a consumed message')
+  )
+  .add(
+    'ProducerMessage component with error',
+    renderHelper(ProducerMessage, 'An error occurred with a produced message')
+  );

--- a/ui/src/Elements/Message/Message.stories.js
+++ b/ui/src/Elements/Message/Message.stories.js
@@ -3,22 +3,23 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
-import {
-  ConsumerMessage,
-  ProducerMessage,
-} from './index.js';
+import { ConsumerMessage, ProducerMessage } from './index.js';
 import MessageReadme from './README.md';
 
 const renderHelper = (
   Component,
   defaultErrorMessage,
+  defaultIsFirst = false,
+  defaultIsSelected = false,
   defaultMessagePartition = 0,
   defaultMessageOffset = 100,
   defaultMessageValue = 'Hello World!',
-  defaultMessageTimestamp = new Date().getTime(),
+  defaultMessageTimestamp = new Date().getTime()
 ) => () => {
+  const isFirst = boolean('First message', defaultIsFirst);
+  const isSelected = boolean('Selected message', defaultIsSelected);
   const message = {
-    topic: 'demo'
+    topic: 'demo',
   };
   message.partition = number('Message partition', defaultMessagePartition);
   message.offset = number('Message offset', defaultMessageOffset);
@@ -27,6 +28,8 @@ const renderHelper = (
 
   const className = text('Custom CSS classname', undefined);
   const props = {
+    isFirst,
+    isSelected,
     message,
     className,
     onInteraction: action('handleClick'),
@@ -35,11 +38,11 @@ const renderHelper = (
   const errorMessage = text('Error message', defaultErrorMessage);
   if (errorMessage) {
     props.error = {
-      message: errorMessage
+      message: errorMessage,
     };
   }
 
-  return <Component {...props}/>;
+  return <Component {...props} />;
 };
 
 storiesOf('Elements/Message', module)
@@ -57,6 +60,14 @@ storiesOf('Elements/Message', module)
   .add(
     'ProducerMessage component (default props)',
     renderHelper(ProducerMessage)
+  )
+  .add(
+    'ConsumerMessage component with first message',
+    renderHelper(ConsumerMessage, undefined, true)
+  )
+  .add(
+    'ProducerMessage component with first message',
+    renderHelper(ProducerMessage, undefined, true)
   )
   .add(
     'ConsumerMessage component with error',

--- a/ui/src/Elements/Message/Message.view.js
+++ b/ui/src/Elements/Message/Message.view.js
@@ -1,0 +1,194 @@
+/* eslint-disable react/no-multi-comp */ // disabled as we have a hoc funtion in file
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  ClickableTile,
+  ExpandableTile,
+  Tile,
+  TileAboveTheFoldContent,
+  TileBelowTheFoldContent,
+} from 'carbon-components-react';
+import { CheckmarkFilled16, ErrorFilled16 } from '@carbon/icons-react';
+import { isEmpty, isFunction } from 'lodash-es';
+import clsx from 'clsx';
+
+import { Body } from '../Text/index.js';
+import { useTranslate } from '../../ReactCustomHooks/index.js';
+import { translations, CONSUMER, PRODUCER } from './Message.assets.js';
+
+const Message = (props) => {
+  const {
+    usage,
+    className,
+    isFirst,
+    message,
+    error,
+    onInteraction,
+    ...others
+  } = props;
+
+  const classesToApply = clsx('Message', `Message--${usage}`, {
+    [`Message--${usage}-first`]: isFirst,
+    [`Message--${usage}-error`]: error,
+    [className]: className,
+  });
+
+  let messageJSX;
+  if (error) {
+    messageJSX = renderErrorTile(error);
+  } else if (usage === CONSUMER) {
+    messageJSX = renderConsumerMessageTile(message, onInteraction);
+  } else {
+    messageJSX = renderProducerMessageTile(message, onInteraction);
+  }
+
+  return (
+    <div {...others} className={classesToApply}>
+      {messageJSX}
+    </div>
+  );
+};
+
+const renderConsumerMessageTile = (message, onInteraction) => {
+  const { partition, offset, timestamp, value } = message;
+  const translate = useTranslate(translations);
+  const valueSize = isEmpty(value) ? '0' : value.length.toString();
+  return (
+    <ExpandableTile
+      expanded={false}
+      {...getInteractionHandler(onInteraction, CONSUMER, message)}
+      className={'Message__tile--consumer'}
+    >
+      <TileAboveTheFoldContent>
+        <div className={'Message__consumer-details'}>
+          <div>
+            {renderValueWithLabel(translate('PARTITION'), partition)}
+            {renderValueWithLabel(translate('OFFSET'), offset)}
+          </div>
+          <div>
+            <div>
+              <Body>
+                {translate('CONSUMED_AT', {
+                  timestamp: new Date(timestamp).toLocaleString(),
+                })}
+              </Body>
+            </div>
+            <div>
+              <Body>{translate('SIZE', { bytesCount: valueSize })}</Body>
+            </div>
+          </div>
+        </div>
+      </TileAboveTheFoldContent>
+      <TileBelowTheFoldContent>
+        <div className={'Message__consumer-payload'}>
+          {renderValueWithLabel('Payload', value)}
+        </div>
+      </TileBelowTheFoldContent>
+    </ExpandableTile>
+  );
+};
+
+const renderProducerMessageTile = (message, onInteraction) => {
+  const { partition, offset } = message;
+  const translate = useTranslate(translations);
+
+  return (
+    <ClickableTile
+      {...getInteractionHandler(onInteraction, PRODUCER, message)}
+      className={'Message__tile--producer'}
+    >
+      <div>
+        <CheckmarkFilled16 className={'Message__icon--checkmark'} />
+        {renderValueWithLabel(translate('PARTITION'), partition)}
+        {renderValueWithLabel(translate('OFFSET'), offset)}
+      </div>
+    </ClickableTile>
+  );
+};
+
+const renderErrorTile = (error) => {
+  const { message } = error;
+  return (
+    <Tile className={'Message__tile--error'}>
+      <ErrorFilled16 className={'Message__icon--error'} />
+      <div className={'Message__error-message'}>
+        <Body>{message}</Body>
+      </div>
+    </Tile>
+  );
+};
+
+const renderValueWithLabel = (label, value) => {
+  return (
+    <div className={'Message__labelled-value'}>
+      <div className={'Message__label'}>
+        <Body>{label}</Body>
+      </div>
+      <div className={'Message__value'}>{value}</div>
+    </div>
+  );
+};
+
+const getInteractionHandler = (onInteraction, usage, message) => {
+  const handlerProps = {};
+
+  if (isFunction(onInteraction)) {
+    handlerProps.handleClick = (event) => onInteraction(event, usage, message);
+  }
+  return handlerProps;
+};
+
+const commonProps = {
+  /** optional - add any specific styling classes to this component */
+  className: PropTypes.string,
+  /** optional - indicate the first message */
+  isFirst: PropTypes.bool,
+  /** optional - Kafka message */
+  message: PropTypes.shape({
+    topic: PropTypes.string.isRequired,
+    partition: PropTypes.number.isRequired,
+    offset: PropTypes.number.isRequired,
+    timestamp: PropTypes.number.isRequired,
+    value: PropTypes.string.isRequired,
+  }),
+  /** optional - Error details **/
+  error: PropTypes.shape({
+    message: PropTypes.string,
+  }),
+  /** optional - interaction handler function */
+  onInteraction: PropTypes.func,
+};
+
+const commonDefaultProps = {
+  className: '',
+};
+
+Message.propTypes = {
+  /** required - the style applied to this component */
+  usage: PropTypes.string.isRequired,
+  ...commonProps,
+};
+
+Message.defaultProps = {
+  usage: CONSUMER,
+  ...commonDefaultProps,
+};
+
+// high order component for specific Message types
+const withMessageUsage = (usageChoice, name) => {
+  // we want to set the type - so destructure and dont use type here
+  // eslint-disable-next-line no-unused-vars
+  const component = ({ usage, ...others }) => (
+    <Message {...others} usage={usageChoice} />
+  );
+  component.displayName = name;
+  component.propTypes = { ...commonProps };
+  component.defaultProps = { ...commonDefaultProps };
+  return component;
+};
+
+const ProducerMessage = withMessageUsage(PRODUCER, 'ProducerMessage');
+const ConsumerMessage = withMessageUsage(CONSUMER, 'ConsumerMessage');
+
+export { ProducerMessage, ConsumerMessage };

--- a/ui/src/Elements/Message/README.md
+++ b/ui/src/Elements/Message/README.md
@@ -1,0 +1,59 @@
+# Message
+
+This component represents a Kafka message, either produced to the broker or
+consumed from the broker. Produced and consumed messages are styled and
+structured differently and both can be supplied with interaction functions.
+
+## Properties
+
+Assuming use of the `Message` component directly, the named properties which are
+expected are as follows:
+
+- `className` - optional - add any specific styling classes to this component.
+This will be appended after the class which sets the type style, allowing
+modification of the styling if needed.
+- `usage` - required - the style and structure applied to this component depending
+  on the type of message. Must be either:
+  - `consumer` - for messages that are consumed from Kafka
+  - `producer` - for messages that are produced to Kafka
+- `isFirst` - optional - enables additional styling to indicate the first message.
+- `message` - optional - a shape containing the Kafka topic, partition,
+  offset, value and timestamp
+- `error` - optional - a shape containing the error details. Overrides `message`
+  if both exist.
+- `onInteraction` - optional - a function invoked on hover, tab, click, etc. The
+  interaction event, `usage` value and `message` value are passed to the
+  function in that order.
+
+_Note_: All `usage` values are exported alongside the component for ease of use.
+
+Any property which is not matched will be passed onto the parent element
+rendered as a part of this component. Do also note if using one of the named
+styled components, the `usage` property is provided for you.
+
+## Example usage
+
+Example usage of the `Message` component, passing both a `usage` and custom
+`className` property. This would result in a consumed message being
+rendered, as well as the styling defined in the `myclass` css class.
+
+```
+<Message usage={'consumer'} className={'myclass'} message={aConsumedMessage}/>
+```
+
+Note that the `Message` component itself is not exposed. Instead, `ConsumerMessage`
+and `ProducerMessage` named/higher order components are exposed for use. These
+in effect abstract the `usage` property away.
+
+For example:
+
+```
+<ProducerMessage isFirst={true} message={aProducedMessage} />
+```
+
+The full set of exposed components and constants are as follows:
+
+- `ProducerMessage` - Message component with producer styling/structure
+- `ConsumerMessage` - Message component with consumer styling/structure
+- `PRODUCER` - producer usage constant
+- `CONSUMER` - consumer usage constant

--- a/ui/src/Elements/Message/index.js
+++ b/ui/src/Elements/Message/index.js
@@ -1,0 +1,2 @@
+export { CONSUMER, PRODUCER } from './Message.assets.js';
+export * from './Message.view.js';

--- a/ui/src/Elements/README.md
+++ b/ui/src/Elements/README.md
@@ -37,8 +37,8 @@ where;
     - `index.js` for exposing any 'public' exported asset - ie the component,
     constants used, etc
     - `README.md` is the documentation/design doc for this component
-    - `*.spec.js` are the behavioual tests for this component 
-    - `*.assets.js` are reuasble assets used in the test, storybook stories,
+    - `*.spec.js` are the behavioural tests for this component
+    - `*.assets.js` are reusable assets used in the test, storybook stories,
     or constants used by the component
     - `*.stories.js` contains the Storybook entries for this component
     - `*.view.js` is the component rendering logic itself
@@ -49,4 +49,5 @@ All of these files should follow the style guide for this codebase, which
 can be found [here](../../docs/CodeStyle.md).
 
 ### List of currently implemented Elements
+- [`Message`](./Message/README.md)
 - [`Text`](./Text/README.md)

--- a/ui/src/Elements/index.js
+++ b/ui/src/Elements/index.js
@@ -1,0 +1,2 @@
+export * from './Message/index.js';
+export * from './Text/index.js';

--- a/ui/src/ReactCustomHooks/useTranslate/README.md
+++ b/ui/src/ReactCustomHooks/useTranslate/README.md
@@ -99,7 +99,7 @@ In your code, you would use the hook as follows:
 
 ```
 import { translations } from 'MyComponent.assets.js';
-import translate = useTranslate(translations);
+const translate = useTranslate(translations);
 ```
 
 and as shown above, call the returned function where required:

--- a/ui/src/ReactCustomHooks/useTranslate/README.md
+++ b/ui/src/ReactCustomHooks/useTranslate/README.md
@@ -1,12 +1,12 @@
 # useTranslate
 
 useTranslate is a custom hook which enables internationalisation in the UI by
-abstracting strings of text being rendered into named keys with inserts. The 
+abstracting strings of text being rendered into named keys with inserts. The
 hook can be provided a bundle of translations, which will then be merged with
 a set of commonly used strings. See [this guide](#format) for a summary of the format
-used by the hook for translation keys and values, and how this works for 
+used by the hook for translation keys and values, and how this works for
 multiple locales. The hook can also be provided a locale directly as a second
-parameter. If not provided, it will default to use `navigator.language` from 
+parameter. If not provided, it will default to use `navigator.language` from
 the browser.
 
 The hook returns a function, which when called can be provided two parameters;
@@ -15,15 +15,15 @@ When called, the translation function will determine the user's locale, find
 a the string to use, and perform any required inserts (mapping the key provided
 in the object to the first instance found in the string, delimited by `${}`).
 
-For example, 
+For example,
 
-`<p>Hello John Doe!</p>` 
+`<p>Hello John Doe!</p>`
 
 would become (in your React code)
 
 `<p>{translate('WELCOME', {name: 'John Doe'})</p>`
 
-where the translation proviuded when creating the hook was:
+where the translation provided when creating the hook was:
 
 ```
 {
@@ -41,7 +41,7 @@ In addition, if required, React components can be inserted as well:
 
 ```
 <p>{translate('WELCOME_WITH_LINK', {
-    name: 'John Doe', 
+    name: 'John Doe',
     link: (<a href={'/users/john.doe'} key={'account-link'}>
                 {translate('ACCESS_ACCOUNT')}
            </a>)
@@ -63,7 +63,7 @@ will return/render to the user:
 
 `<p>Hello John Doe! <a href='/users/john.doe'>Access your account here</a></p>`
 
-Do note however that when passing JSX as an insert, it must have a key 
+Do note however that when passing JSX as an insert, it must have a key
 associated with it ([as per this best practise](https://reactjs.org/docs/lists-and-keys.html#keys)).
 
 Finally, if you want to use a translated string in an HTML attribute, such as
@@ -87,10 +87,10 @@ will return/render to the user:
 
 `<img src={myImage.png} alt='Descriptive text for this image' />`
 
-Note in this case the extra parameter at the end of the translate call. This 
+Note in this case the extra parameter at the end of the translate call. This
 causes the hook to return a string, rather than JSX (as attribute values need
 to be strings). _Do note that object inserts passed in when called using this
-method will be returned as `[object Object]` - as this is how JS objects are 
+method will be returned as `[object Object]` - as this is how JS objects are
 printed when put into a string._
 
 ## Usage
@@ -98,8 +98,8 @@ printed when put into a string._
 In your code, you would use the hook as follows:
 
 ```
-const { translations } from 'MyComponent.assets.js';
-const translate = useTranslate(translations);
+import { translations } from 'MyComponent.assets.js';
+import translate = useTranslate(translations);
 ```
 
 and as shown above, call the returned function where required:
@@ -110,7 +110,7 @@ and as shown above, call the returned function where required:
 
 Your provided translations will be merged with the default provided set, which
 will make up the corpus available for you to use. We recommend 'namespacing'
-your translation keys, eg `MYCOMPONENT_TEXT`, to reduce the chance of 
+your translation keys, eg `MYCOMPONENT_TEXT`, to reduce the chance of
 collisions.
 
 The full signiture of the returned function is as follows:
@@ -119,8 +119,8 @@ The full signiture of the returned function is as follows:
 
 - `key` - string, required - the translation key to use to render the desired
 value
-- `inserts` - object, optional - a JS object where the keys match with the 
-above specified `${}` delimeters. At run time, the value for this key is 
+- `inserts` - object, optional - a JS object where the keys match with the
+above specified `${}` delimeters. At run time, the value for this key is
 inserted into the returned value.
 - `returnAsString` - boolean, optional, defaults to false - by default, the
 hook will return JSX. By setting this to true, a string value will be returned
@@ -139,5 +139,4 @@ The format of the translation bundles is as follows:
 ```
 
 As per usage above, a user of `useTranslate` would provide translations in this
-format, from a file with the `*.i18n.json` suffix. 
-
+format, from a file with the `*.i18n.json` suffix.

--- a/ui/src/ReactCustomHooks/useWebSocket/useWebSocket.hook.js
+++ b/ui/src/ReactCustomHooks/useWebSocket/useWebSocket.hook.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { NO_OP, EMPTY_OBJ } from 'Utils';
+import { NO_OP, EMPTY_OBJ } from '../../Utils/index.js';
 
 const STATUS = {
   CONNECTING: WebSocket.CONNECTING,

--- a/ui/src/ReactCustomHooks/useWebSocket/useWebSocket.hook.js
+++ b/ui/src/ReactCustomHooks/useWebSocket/useWebSocket.hook.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { NO_OP, EMPTY_OBJ } from '../../Utils/index.js';
+import { NO_OP, EMPTY_OBJ } from 'Utils';
 
 const STATUS = {
   CONNECTING: WebSocket.CONNECTING,


### PR DESCRIPTION
- This commit adds the ConsumerMessage and ProducerMessage components,
 providing components that represent a produced or consumed Kafka
 message, displayed as a Carbon ClickableTile or Carbon ExpandableTile
 respectively.

Contributes to: #55

Signed-off-by: Andrew Borley <borley@uk.ibm.com>